### PR TITLE
Allow a custom container for the results dropdown

### DIFF
--- a/src/jquery.postcodes.js
+++ b/src/jquery.postcodes.js
@@ -77,6 +77,7 @@
     dropdown_id: "idpc_dropdown",
     dropdown_select_message: "Please select your address",
     dropdown_class: "",
+    dropdown_container: undefined,
 
     // Error Message Configuration
     $error_message: undefined,
@@ -440,7 +441,15 @@
       }).appendTo(dropDown);
     }
 
-    dropDown.appendTo(self.$context)
+    var dropdownContainer;
+    if ($(this.dropdown_container).length) {
+      // Use custom dropdown container
+      dropdownContainer = $(this.dropdown_container).first();
+    } else {
+      dropdownContainer = this.$context;
+    }
+
+    dropDown.appendTo(dropdownContainer)
     .change(function () {
       var address;
       var index = $(this).val();

--- a/test/jquery.postcodes_test.js
+++ b/test/jquery.postcodes_test.js
@@ -55,6 +55,7 @@ QUnit.testStart(function(testDetails){
   var $dropdown;
   var inputId;
   var buttonId;
+  var dropdownContainerId;
   var defaults = $.idealPostcodes.defaults;
   var apiKey = "iddqd";
 
@@ -467,6 +468,45 @@ QUnit.testStart(function(testDetails){
     $input_field.val("asd");
     $lookup_button.trigger("click");
     isPresent("error message", defaults.error_message_id);
+  });
+
+  module("Postcode Lookups: Custom Dropdown Container", {
+    setup: function () {
+      dropdownContainerId = "custom-dropdown-container";
+      $("<div />", {
+        id: dropdownContainerId,
+      })
+      .html("Results: ")
+      .appendTo($("#qunit-fixture"));
+      $("#postcode_lookup_field").setupPostcodeLookup({
+        api_key: apiKey,
+        disable_interval: 0,
+        dropdown_container: "#" + dropdownContainerId,
+        onLookupSuccess: function () {
+          $.event.trigger("completedJsonp");
+        },
+        onLookupError: function () {
+          $.event.trigger("completedJsonp");
+        }
+      });
+      $input_field = $("#"+defaults.input_id);
+      $lookup_button = $("#"+defaults.button_id);
+    },
+    teardown: function () {
+      $(document).off("completedJsonp");
+    }
+  });
+
+  asyncTest("Dropdown is added to a custom parent element", 1, function () {
+    $input_field.val("ID11QD");
+    $(document).on("completedJsonp", function () {
+      start();
+      var dropdownParentActual = $("#" + defaults.dropdown_id).first().parent()[0];
+      var dropdownParentExpected = $("#" + dropdownContainerId).first()[0];
+      strictEqual(dropdownParentActual, dropdownParentExpected,
+        "the dropdown menu is a child of the custom dropdown container element");
+    });
+    $lookup_button.trigger("click");
   });
 
   module("jQuery#setupPostcodeLookup with passing pre-initialisation check", { 


### PR DESCRIPTION
Adds the ability for a custom container to be specified for the results dropdown to be added to.

Similar to the custom input and button, the custom dropdown container is specified by providing a CSS-selector as a `dropdown_container` option passed to the `setupPostcodeLookup` function:
```javascript
$("#postcode_lookup_field").setupPostcodeLookup({
  dropdown_container: "#results-container"
});
```

If no `dropdown_container` is specified then the current behaviour remains – the results dropdown is added to the postcode lookup's context.